### PR TITLE
Fix `dompurify` import for `sanitize`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,6 @@
 import React from 'react'
-import { sanitize } from 'dompurify'
+import dompurify from 'dompurify';
+const sanitize = dompurify.sanitize
 
 const Gist = ({
   url,


### PR DESCRIPTION
In `vite`, this causes an import error as shown in https://github.com/GeorgeGkas/super-react-gist/issues/4. 
